### PR TITLE
Add Transparent Texture for City Building Stack

### DIFF
--- a/Assets/CityMap/CityImage/CityImagery.asset
+++ b/Assets/CityMap/CityImage/CityImagery.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
     Id: 
     Modified: 
     UserName: 
-  _mapId: mapbox://styles/mapbox/satellite-streets-v10
+  _mapId: mapbox://styles/mapbox/dark-v9
   _useCompression: 1
   _useMipMap: 0
   _useRetina: 0

--- a/Assets/CityMap/CityMesh/BuildingLayer/CityTransparentBuildingStack.meta
+++ b/Assets/CityMap/CityMesh/BuildingLayer/CityTransparentBuildingStack.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1ace1c77095a29c40901cf7b463691bc
+folderAsset: yes
+timeCreated: 1507423719
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CityMap/CityMesh/BuildingLayer/CityTransparentBuildingStack/CityTransparentBuildingMaterial.mat
+++ b/Assets/CityMap/CityMesh/BuildingLayer/CityTransparentBuildingStack/CityTransparentBuildingMaterial.mat
@@ -1,0 +1,76 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: CityTransparentBuildingMaterial
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.41608998, g: 0.5771746, b: 0.7647059, a: 0.147}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/CityMap/CityMesh/BuildingLayer/CityTransparentBuildingStack/CityTransparentBuildingMaterial.mat.meta
+++ b/Assets/CityMap/CityMesh/BuildingLayer/CityTransparentBuildingStack/CityTransparentBuildingMaterial.mat.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 1124d777cd7670e4cb79d79f6a43dd3e
+timeCreated: 1507423733
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CityMap/CityMesh/BuildingLayer/CityTransparentBuildingStack/CityTransparentBuildingTextureModifier.asset
+++ b/Assets/CityMap/CityMesh/BuildingLayer/CityTransparentBuildingStack/CityTransparentBuildingTextureModifier.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d86f7dc89b3e33408563e4ada9d1c74, type: 3}
+  m_Name: CityTransparentBuildingTextureModifier
+  m_EditorClassIdentifier: 
+  Active: 1
+  _textureTop: 0
+  _useSatelliteTexture: 0
+  _topMaterials: []
+  _textureSides: 0
+  _sideMaterials: []

--- a/Assets/CityMap/CityMesh/BuildingLayer/CityTransparentBuildingStack/CityTransparentBuildingTextureModifier.asset.meta
+++ b/Assets/CityMap/CityMesh/BuildingLayer/CityTransparentBuildingStack/CityTransparentBuildingTextureModifier.asset.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 50bcd3f4139c2fd468a2a90af8389596
+timeCreated: 1507423867
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/mapbo.unity
+++ b/Assets/mapbo.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4465934, g: 0.49642956, b: 0.5748249, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657826, g: 0.49641263, b: 0.57481676, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -77,17 +77,15 @@ LightmapSettings:
     m_PVRDirectSampleCount: 32
     m_PVRSampleCount: 500
     m_PVRBounces: 2
-    m_PVRFilterTypeDirect: 0
-    m_PVRFilterTypeIndirect: 0
-    m_PVRFilterTypeAO: 0
+    m_PVRFiltering: 0
     m_PVRFilteringMode: 1
     m_PVRCulling: 1
     m_PVRFilteringGaussRadiusDirect: 1
     m_PVRFilteringGaussRadiusIndirect: 5
     m_PVRFilteringGaussRadiusAO: 2
-    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
-    m_PVRFilteringAtrousPositionSigmaIndirect: 2
-    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_PVRFilteringAtrousColorSigma: 1
+    m_PVRFilteringAtrousNormalSigma: 1
+    m_PVRFilteringAtrousPositionSigma: 1
   m_LightingDataAsset: {fileID: 0}
   m_UseShadowmask: 1
 --- !u!196 &4
@@ -109,8 +107,6 @@ NavMeshSettings:
     manualTileSize: 0
     tileSize: 256
     accuratePlacement: 0
-    debug:
-      m_Flags: 0
   m_NavMeshData: {fileID: 0}
 --- !u!1 &753947106
 GameObject:
@@ -240,11 +236,11 @@ Camera:
   m_TargetEye: 3
   m_HDR: 1
   m_AllowMSAA: 1
-  m_AllowDynamicResolution: 0
   m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
+  m_StereoMirrorMode: 0
 --- !u!4 &1295823261
 Transform:
   m_ObjectHideFlags: 0
@@ -302,7 +298,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _initializeOnStart: 1
-  _latitudeLongitudeString: 40.7648, -73.9808
+  _latitudeLongitudeString: 42.3605, -71.0596
   _zoom: 16
   _root: {fileID: 1595414760}
   _tileProvider: {fileID: 1595414758}


### PR DESCRIPTION
CityBuildingsStack under CityMap > CityMesh folder can assign Game Object Modifiers to be either CityBuildingTexture (opaque, building color) or CityTransparentBuildingTextureModifier (transparent).